### PR TITLE
Document Object Model - Kleine Fixes

### DIFF
--- a/general/document-object-model.md
+++ b/general/document-object-model.md
@@ -24,7 +24,7 @@ inhalt:
         simple: ""
 
     -   name: "Weiterführende Links"
-        anchor: weiterfuehrende-links
+        anchor: weiterfhrende-links
         simple: ""
 
 entry-type: in-discussion


### PR DESCRIPTION
Es wird keine kramdown-Syntax in HTML-Teilen unterstützt.
