### PR TITLE
fixxed a lot of links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
         <!-- /Atom Feed -->
         {% endif %}
 
-        <script type="text/javascript" src="http://codeorigin.jquery.com/jquery-2.0.3.min.js"></script>
+        <script type="text/javascript" src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
         <script type="text/javascript" src="/assets/scroll.js"></script>
     </head>
     <body>

--- a/code-optimizing/if.md
+++ b/code-optimizing/if.md
@@ -43,7 +43,7 @@ Zuerst sei ein oft vorkommender Mythos aufgeklärt:
   
 Das Wesen einer Schleife ist die Wiederholung. `if` bildet einen Block aus Anweisungen und Ausdrücken.
 
-`if` ist eine [Kontrollstruktur](http://www.php.net/manual/de/language.control-structures.php) aber deshalb noch lange keine Schleife.
+`if` ist eine [Kontrollstruktur](http://php.net/manual/de/language.control-structures.php) aber deshalb noch lange keine Schleife.
 
 
 ### Notierung  

--- a/debugging/standardfehler.md
+++ b/debugging/standardfehler.md
@@ -55,7 +55,7 @@ Es gibt zwei prinzipielle Lösungsansätze. Der erste besteht darin, die gesamte
 
 Näheres findet man im Hauptartikel zum [EVA Prinzip]({{ site.url }}/jumpto/eva-prinzip/).
 
-Variante zwei nutzt den sogenannten [Ausgabepuffer](http://www.php.net/manual/de/intro.outcontrol.php), den man nutzen kann, um Bildschirmausgaben vorübergehend in eine Variable umzuleiten. Das funktioniert sogar mit Inline-HTML:
+Variante zwei nutzt den sogenannten [Ausgabepuffer](http://php.net/manual/de/intro.outcontrol.php), den man nutzen kann, um Bildschirmausgaben vorübergehend in eine Variable umzuleiten. Das funktioniert sogar mit Inline-HTML:
 
 ~~~ php
 <?php

--- a/dev-enviroment/composer.md
+++ b/dev-enviroment/composer.md
@@ -102,7 +102,7 @@ Composer selbst steht zum einen als phar-Executable bereit, verwenden wirst du a
 * Starte den Installer durch einen doppelklick auf die heruntergeladene Datei. Alle Windowsversionen mit aktivierter Benutzerkontrolle werden dich danach fragen ob dem Installer erlaubt werden soll ausgeführt zu werden, bestätige diese anfrage mit **Ja**.  
 
 * Klicke auf **Next >**  
-Überprüfe den Pfad zu deiner PHP-Installation. Dieses Guide setzt voraus das du bereits eine Funktionierende [XAMPP](http://www.apachefriends.org/de/xampp.html), [WampServer](http://www.wampserver.com/en/), [SecureWAMP](http://securewamp.org/de/), [ZendServer](http://www.zend.com/de/products/server/) oder [WPN-XM](http://wpn-xm.org/) Installation hast. In der Regel brauchst du hier nichts verändern, der Installer arretiert das Verzeichnis zur PHP Installation der Jeweiligen PHP-Umgebungen selbst. Bestätige dort bitte mit Klick auf **Next >**  
+Überprüfe den Pfad zu deiner PHP-Installation. Dieses Guide setzt voraus das du bereits eine Funktionierende [XAMPP](http://www.apachefriends.org/de/index.html), [WampServer](http://www.wampserver.com/en/), [SecureWAMP](http://securewamp.org/de/), [ZendServer](http://www.zend.com/de/products/server/) oder [WPN-XM](http://wpn-xm.org/) Installation hast. In der Regel brauchst du hier nichts verändern, der Installer arretiert das Verzeichnis zur PHP Installation der Jeweiligen PHP-Umgebungen selbst. Bestätige dort bitte mit Klick auf **Next >**  
 
 * Klicke auf **Install**  
 

--- a/dev-enviroment/editors-ide.md
+++ b/dev-enviroment/editors-ide.md
@@ -55,7 +55,7 @@ Ein PHP Editor ist eine Anwendung die grundlegende Editor-Funktionen können mus
 
 
 * **Kate** - by KDE Group  
-    Webseite: [http://www.kate-editor.org](http://www.kate-editor.org)  
+    Webseite: [http://kate-editor.org](http://kate-editor.org)  
     UI-Sprache: sehr viele  
     Features: Viele - Siehe Webseite und <a href="http://de.wikipedia.org/wiki/Kate_(KDE)">http://de.wikipedia.org/wiki/Kate_(KDE)</a>  
     Erweiterbar: Ja  
@@ -86,7 +86,7 @@ Ein PHP Editor ist eine Anwendung die grundlegende Editor-Funktionen können mus
 
 
 * **ActiveState Komodo Edit** - **empfohlen**{: style="color: #006400"}  
-    Webseite: [http://www.activestate.com/komodo-edit](http://www.activestate.com/komodo-edit)  
+    Webseite: [http://komodoide.com/](http://komodoide.com/)  
     Ui-Sprache: englisch  
     Features: Siehe Webseite  
     Kostet: **kostenlos**  

--- a/email/standard-mail-validation.md
+++ b/email/standard-mail-validation.md
@@ -136,7 +136,7 @@ var_dump(checkEMailDomainDNS('mail@example.com'));  // true
 
 Wer sich genauer für die Regex-Prüfung interessiert, dem sei [dieser Link](http://squiloople.com/2009/12/20/email-address-validation/) empfohlen. Danke an [Trainmaster](http://www.php.de/member.php?u=20243) für den Link.
 
-Wer sich dafür interessiert wie eigentlich filter_var() validiert, dem sei ein Blick in den Quelltext von PHP empfohlen oder etwas einfacher hier in [diesem Forumsbeitrag](http://www.php.de/wiki-diskussionsforum/101439-sinnvolle-standard-verfahren-zur-e-mail-validierung-3.html#post748505). Danke an [Asterixus](http://www.php.de/member.php?u=21236) für die Recherche.
+Wer sich dafür interessiert wie eigentlich filter_var() validiert, dem sei ein Blick in den Quelltext von PHP empfohlen oder etwas einfacher hier in [diesem Forumsbeitrag](http://www.php.de/wiki-diskussionsforum/101439-erledigt-sinnvolle-standard-verfahren-zur-e-mail-validierung-3.html#post748505). Danke an [Asterixus](http://www.php.de/member.php?u=21236) für die Recherche.
 
 
 #### RFC zum Thema E-Mail

--- a/general/document-object-model.md
+++ b/general/document-object-model.md
@@ -86,7 +86,7 @@ Gecko-Browser interpretieren die Leerzeichen und Zeilenumbrüche zwischen den
 Elementen ebenfalls als <code>#text</code>-Knoten, weshalb es oft zu
 unerwarteten Skript-Fehlern kommt. Dieses Verhalten ist laut W3C-Standard
 allerdings nicht korrekt. Eine mögliche Lösung dieses Problems gibt es im <a
-href="http://developer.mozilla.org/en/whitespace_in_the_DOM">Mozilla Developer
+href="https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Whitespace_in_the_DOM">Mozilla Developer
 Center</a>.
 
 </div>
@@ -193,5 +193,4 @@ var div = document.getElementById('wrapper'),
 * [W3C Document Object Model](http://www.w3.org/DOM/)
 * [Document Object Model - Wikipedia](http://de.wikipedia.org/wiki/Document_Object_Model)
 * [JavaScript DOM](http://krook.org/jsdom/)
-* [Javascript Dom objects](http://www.w3schools.com/js/js_obj_htmldom.asp)
 

--- a/general/php-ini.md
+++ b/general/php-ini.md
@@ -35,8 +35,8 @@ inhalt:
       anchor: fremdinitialiserung
       simple: ""
 
-    - name: "Kollision von Parameterangaben"
-      anchor: kollision-von-parameterangaben
+    - name: "Kollision von Parametern"
+      anchor: kollision-von-parametern
       simple: ""
 
     - name: "Alternative Verwendung von Superglobalen Arrays"

--- a/introduction/grundlagen.md
+++ b/introduction/grundlagen.md
@@ -112,7 +112,7 @@ So, und nun ein erfolgreiches Selbststudium!
   * **Frameworks:**
     * **YAML:**
       * [Home: Yet Another Multicolumn Layout \| An (X)HTML/CSS
-        Framework](http://www.yaml.de/de/home.html){: target="_blank"}  
+        Framework](http://www.yaml.de/){: target="_blank"}  
         Die Webseite zum CSS Framework YAML. Das Framework stammt vom
         deutschen Entwickler Dirk Jesse. Auf der Webseite gibt es einen
         YAML Builder mit dem man sehr einfach CSS Layouts gestallten
@@ -145,19 +145,19 @@ So, und nun ein erfolgreiches Selbststudium!
     
     
     * **ExtJS:**
-      * [Ext JS - Client-side JavaScript Framework](http://www.extjs.com/products/extjs/?ref=learnmorebluebutton){: target="_blank"}  
+      * [Ext JS - Client-side JavaScript Framework](http://www.sencha.com/products/extjs/?ref=learnmorebluebutton){: target="_blank"}  
         Dokumentation zu ExtJS. Beispiele und API Dokumentation.
     
     
     * **jQuery:**
-      * [Main Page - jQuery JavaScript Library](http://docs.jquery.com/Main_Page){: target="_blank"}  
+      * [Main Page - jQuery JavaScript Library](http://api.jquery.com/){: target="_blank"}  
         Dokumentation zu jQuery. Bietet Erklärungen und Beispiele zu
         allen jQuery Funktionen.
 
 
 ##### PHP
 
-  * [PHP: PHP-Handbuch - Manual](http://www.php.net/manual/de/){: target="_blank"}  
+  * [PHP: PHP-Handbuch - Manual](http://php.net/manual/de/){: target="_blank"}  
     Offizielle PHP Dokumentation. Als Funktionsreferenz zum
     Nachschlagen oder suchen von Funktionen zu empfehlen, auch für das
     Nachlesen von Themen, aber eher nicht als Tutorial für Anfänger zu
@@ -203,7 +203,7 @@ So, und nun ein erfolgreiches Selbststudium!
     
     
     * **CodeIgniter**
-      * [http://codeigniter.com/](http://codeigniter.com/){: target="_blank"} 
+      * [http://ellislab.com/codeigniter](http://ellislab.com/codeigniter){: target="_blank"} 
         CodeIgniter ist ein schnelles und leichtgewichtiges PHP
         Framework.
     
@@ -285,7 +285,7 @@ So, und nun ein erfolgreiches Selbststudium!
       * [Using prototype.js v1.5.0](http://www.sergiopereira.com/articles/prototype.js.html){: target="_blank"}  
         Einführung in die Nutzung von prototype.
       * [Prototype JavaScript framework: Prototype Tips and
-        Tutorials](http://www.prototypejs.org/learn){: target="_blank"}  
+        Tutorials](http://prototypejs.org/learn/){: target="_blank"}  
         Einführung zu prototype von den Entwicklern selbst.  
         **Nachteile:** englisch
     
@@ -390,7 +390,7 @@ So, und nun ein erfolgreiches Selbststudium!
 
 ##### PHP Fortgeschrittene
 
-  * [Professionelle Softwareentwicklung mit PHP 5](http://www.professionelle-softwareentwicklung-mit-php5.de/){: target="_blank"}  
+  * [Professionelle Softwareentwicklung mit PHP 5](http://professionelle-softwareentwicklung-mit-php5.de/){: target="_blank"}  
     Dieses Tutorial stellt neben der objektorientierten Programmierung
     auch Entwurfsmuster (Design Patterns) und Entwicklungswerkzeuge vor.
     Außerdem umfasst es Themen zur Verarbeitung von XML-Dokumenten, der
@@ -434,7 +434,7 @@ So, und nun ein erfolgreiches Selbststudium!
 ### Bücher
 {: #books}
 
-* [Galileo Computing : Buch : Besser PHP programmieren](http://www.galileocomputing.de/katalog/buecher/titel/gp/titelID-1670){: target="_blank"}  
+* [Galileo Computing : Buch : Besser PHP programmieren](https://www.galileo-press.de/besser-php-programmieren_1670/){: target="_blank"}  
   Dieses Buch führt sehr gut in PHP ein und beleuchtet viele Aspekte
   der Webprogrammierung mit PHP. Zuerst werden die Grundlagen erklärt,
   dann kommt man aber auch schnell zu komplexeren Themen.  
@@ -443,7 +443,7 @@ So, und nun ein erfolgreiches Selbststudium!
   **Vorteile:** Umfangreich, gut erklärt, teils auch etwas humorvoll  
   **Nachteile:** Die Themen werden nicht immer erschöpfend behandelt
 
-* [Galileo Computing : Buch : PHP 5.3 und MySQL 5.1](http://www.galileocomputing.de/katalog/buecher/titel/gp/titelID-2078){: target="_blank"}  
+* [Galileo Computing : Buch : PHP 5.3 und MySQL 5.1](https://www.galileo-press.de/php-53-und-mysql-51_2078/){: target="_blank"}  
   Ein Buch, dass zunächst auf die Grundlagen von PHP eingeht, dann
   aber schnell zu fortgeschrittenen Themen übergeht. Vor allem die
   Datenbankanbindung spielt eine große Rolle.  
@@ -486,7 +486,7 @@ So, und nun ein erfolgreiches Selbststudium!
    **Vorteile:** Gut ausgeführt, sehr umfangreich, es wird ein gutes
   Verständnis von möglichen Sicherheitsrisiken vermittelt
 
-* [Galileo Computing : Buch : Reguläre Ausdrücke](http://www.galileocomputing.de/katalog/buecher/titel/gp/titelID-967){: target="_blank"}  
+* [Galileo Computing : Buch : Reguläre Ausdrücke](https://www.galileo-press.de/regulare-ausdrucke_967/){: target="_blank"}  
   PHP bietet noch weitaus mehr als nur simple print- und
   echo-Anweisungen. Ein großes Thema sind beispielsweise reguläre
   Ausdrücke. Ein weites Themengebiet, das auch nicht immer ganz leicht
@@ -499,7 +499,7 @@ So, und nun ein erfolgreiches Selbststudium!
   **Nachteile:** Die Erklärungen sind nicht immer ganz leicht zu
   verstehen und erfordern manchmal einiges an Konzentration
 
-* [Galileo Computing : Buch : PHP PEAR](http://www.galileocomputing.de/katalog/buecher/titel/gp/titelID-891){: target="_blank"}  
+* [Galileo Computing : Buch : PHP PEAR](https://www.galileo-press.de/php-pear_891/){: target="_blank"}  
   Eine Einführung in die Arbeit mit dem PHP-Repository PEAR. Dabei
   werden sowohl die Installation wie auch ausgewählte PEAR-Pakete
   erklärt.  

--- a/security/hash-etc.md
+++ b/security/hash-etc.md
@@ -57,11 +57,11 @@ Warum man [md5() nicht mehr verwenden sollte](http://de.wikipedia.org/wiki/Messa
 
 Stichwort [Rainbow-Tables](http://de.wikipedia.org/wiki/Rainbow_Table) 
 
-Aus diesem Grund wird von der weiteren Verwendung von MD5 (PHP-Funktion md5()) abgeraten. Ebenso wie  die Funktionen der [SHA-1 Familie](http://de.wikipedia.org/wiki/Secure_Hash_Algorithm#SHA.2FSHA-1).
+Aus diesem Grund wird von der weiteren Verwendung von MD5 (PHP-Funktion md5()) abgeraten. Ebenso wie  die Funktionen der [SHA-1 Familie](http://de.wikipedia.org/wiki/Secure_Hash_Algorithm#SHA-1).
 
 PHP.net empfiehlt an dieser Stelle, auf den SHA256 Algorithmus ebenfalls zu verzichten.
 
-[php.net FAQ "Save Password Hashing"](http://www.php.net/manual/de/faq.passwords.php)
+[php.net FAQ "Save Password Hashing"](http://php.net/manual/de/faq.passwords.php)
 
 
 ##### Gesalzene Hashes
@@ -89,7 +89,7 @@ Beispiel mit "Salz". Gäbe es in einer Rainbow-Table bereits die Kombination zwi
 > ... findet im Internet-Standard MIME (Multipurpose Internet Mail Extensions) Anwendung und wird damit hauptsächlich zum Versenden von E-Mail-Anhängen verwendet. Nötig ist dies, um den problemlosen Transport von beliebigen Binärdaten zu gewährleisten, da SMTP in seiner ursprünglichen Fassung nur für den Versand von 7-Bit-ASCII-Zeichen ausgelegt war. Durch die Kodierung steigt der Platzbedarf des Datenstroms um 33–36 % (33 % durch die Kodierung selbst, bis zu weitere 3 % durch die im kodierten Datenstrom eingefügten Zeilenumbrüche).
 
 
-In PHP stehen dafür die Funktionen [base64_encode()](http://php.net/manual/de/function.base64-encode.php) und [base64_decode()](http://www.php.net/manual/de/function.base64-decode.php) zur Verfügung.
+In PHP stehen dafür die Funktionen [base64_encode()](http://php.net/manual/de/function.base64-encode.php) und [base64_decode()](http://php.net/manual/de/function.base64-decode.php) zur Verfügung.
 
 
 <div class="alert alert-info"><strong>Hinweis!</strong> Die oben erwähnten Funktionen zu verwenden, um Texte "geheim" zu halten oder "unleserlich" zu machen, macht wenig Sinn. Zumeist ist schon am kodierten Ergebnis relativ eindeutig ersichtlich das es sich um das Produkt einer Base64-Kodierung handelt. Hierzu ist eine Verschlüsselung anzuwenden, siehe dazu weiter unten.</div>
@@ -103,5 +103,5 @@ In PHP stehen dafür die Funktionen [base64_encode()](http://php.net/manual/de/f
 
 
 PHP-Funktionen z.B. über die Erweiterung MCrypt: 
-[mcrypt()](http://www.php.net/manual/de/book.mcrypt.php)
+[mcrypt()](http://php.net/manual/de/book.mcrypt.php)
 

--- a/security/sql-injection.md
+++ b/security/sql-injection.md
@@ -93,10 +93,10 @@ Schnittstelle gehörende Funktion genutzt werden. Eine allgemeine Funktion wie
 `addslashes` ist *nicht* ausreichend. Eine Auswahl dieser Funktionen für einige
 Schnittstellen:
 
-* mysql (veraltet): [`mysql_real_escape_string`](http://us1.php.net/manual/en/function.mysql-real-escape-string.php)
-* mysqli: [`mysqli_real_escape_string`](http://us1.php.net/manual/en/mysqli.real-escape-string.php)
-* PDO: [`PDO::Quote`](http://www.php.net/manual/en/pdo.quote.php)
-* postgresql: [`pg_escape_string`](http://www.php.net/manual/en/function.pg-escape-string.php) (und andere)
+* mysql (veraltet): [`mysql_real_escape_string`](http://php.net/manual/en/function.mysql-real-escape-string.php)
+* mysqli: [`mysqli_real_escape_string`](http://php.net/manual/en/mysqli.real-escape-string.php)
+* PDO: [`PDO::Quote`](http://php.net/manual/en/pdo.quote.php)
+* postgresql: [`pg_escape_string`](http://php.net/manual/en/function.pg-escape-string.php) (und andere)
 
 Die Anwendung dieser Funktionen ist quasi immer gleich und nicht sonderlich
 kompliziert: Bevor ein Wert in den Query-String eingefügt wird, muss er die


### PR DESCRIPTION
jQuery: Sends "moved permanent" from codeorigin.\* to code.*
Kate-Editor: Sends "moved permanent" to Domain without www
PHP.net: Sends "moved permanent" to Domain without www
YAML.de: Sends "moved permanent" to Domain without Path
KomodoIDE: Sends "moved permanent" to new Domain
ExtJS: Sends "moved permanent" to new Domain
Codeigniter: Sends "moved permanent" to new Domain
Prototype.js: Sends "moved permanent" to Domain without www and ending slash
Galileocomputing: Sends "moved permanent" to new Domain
Javascript Dom objects: Sends 404, removed
XAMPP: Sends 404, corrected link
php-de/php-ini: #kollision-von-parameterangaben -> #kollision-von-parametern

Notes:
- http://kramdown.rubyforge.org/quickref.html maybe down (in contribute)
- http://dynamicinternet.eu/blog/2007-03-18/tutorial-einfuehrung-in-die-ext-ajax-library/ maybe down (in grundlagen-quellen)
- http://www.phphatesme.com/blog/softwaretechnik/dont-reinvent-the-squared-wheel-die-elbphilharmonie/comment-page-1/#comment-85945 maybe down (in ich-will-das-selbst-schaffen-attituede)
- http://ellislab.com/codeigniter maybe down (in grundlagen-quellen)
- http://de.php.net/manual/de/ini.sect.data-handling.php#ini.register-globals maybe down (in php-ini)
